### PR TITLE
Change hardcoded term for most recent term

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -27,7 +27,7 @@ def scrape_list(url)
       wikiname: li.at_xpath('.//a[not(@class="new")][1]/@title').text,
       party_id: "_ind",
       party: "n/a",
-      term: 2011,
+      term: 2016,
     }
     ScraperWiki.save_sqlite([:name, :term], data)
   end


### PR DESCRIPTION
A new member has been appointed. As there are no official terms, we create an arbitrary term that starts on the date of a new appointment and name it after the year that the appointment is made.

@tmtmtmtm I've also moved the scraper: https://morph.io/everypolitician-scrapers/pontifical-commission-for-vatican-state-wikipedia Could you delete: https://morph.io/tmtmtmtm/pontifical-commission-for-vatican-state-wikipedia?
